### PR TITLE
fix: usage with docker compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ connect_db:
 init_dbs: run_dbs
 	echo "wait for db to start up..."
 	sleep 8
-	docker cp new_db.sql tapis-project-$(api)-postgres-1:/db.sql
+	docker cp new_db.sql $(api)-postgres-1:/db.sql
 	docker-compose exec -T postgres psql -Upostgres -f /db.sql
 
 # ----- wipe database and associated data

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ connect_db:
 init_dbs: run_dbs
 	echo "wait for db to start up..."
 	sleep 8
-	docker cp new_db.sql $(api)_postgres_1:/db.sql
+	docker cp new_db.sql tapis-project-$(api)-postgres-1:/db.sql
 	docker-compose exec -T postgres psql -Upostgres -f /db.sql
 
 # ----- wipe database and associated data


### PR DESCRIPTION
## Overview

Make changes necessary for working environment using Docker Compose v2.

## Related

- mimicked by https://github.com/tapis-project/authenticator/pull/64

## Changes

- **changed** Makefile's constructed name of docker container

## Testing

0. Prune docker containers and volumes.
1. `export API_NAME=authenticator`
2. `make init_dbs`
3. Verify **no** `Error: No such container:path: authenticator_postgres_1:/`.

## Notes

> **Note**
> In Compose V1, an underscore (`_`) was used as the word separator. In Compose V2, a hyphen (`-`) is used as the word separator. [Source.](https://docs.docker.com/compose/migrate/#service-container-names) So, the `Makefile` should reference

> **Important**
> From July 2023 Compose V1 stopped receiving updates. It's also no longer available in new releases of Docker Desktop.
>
> Compose V2 is included with all currently supported versions of Docker Desktop. For more information, see [Migrate to Compose V2](https://docs.docker.com/compose/migrate).
>
> Docker's documentation refers to and describes Compose V2 functionality.
>
> — https://docs.docker.com/compose/release-notes/ (2023-10-09)